### PR TITLE
Add /leaderboard page with embedded HF Space

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -64,11 +64,7 @@ const config: Config = {
           label: 'Docs',
         },
         {to: '/blog', label: 'Blog', position: 'left'},
-        {
-          href: 'https://github.com/yxc20089/OpenRA-Bench',
-          label: 'Leaderboard',
-          position: 'left',
-        },
+        {to: '/leaderboard', label: 'Leaderboard', position: 'left'},
         {
           href: 'https://github.com/yxc20089/OpenRA-RL',
           label: 'GitHub',

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -1,0 +1,24 @@
+import Layout from '@theme/Layout';
+
+const SPACE_URL = 'https://sy30678-openra-bench.hf.space';
+
+export default function Leaderboard() {
+  return (
+    <Layout
+      title="Leaderboard"
+      description="OpenRA-Bench Agent Leaderboard — Compare AI agents playing Red Alert">
+      <main style={{height: 'calc(100vh - 60px)', display: 'flex', flexDirection: 'column'}}>
+        <iframe
+          src={`${SPACE_URL}?embed=true`}
+          style={{
+            flex: 1,
+            width: '100%',
+            border: 'none',
+          }}
+          title="OpenRA-Bench Leaderboard"
+          allow="clipboard-write"
+        />
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/leaderboard` page that embeds the OpenRA-Bench Gradio leaderboard via iframe from HuggingFace Spaces
- Change navbar "Leaderboard" link from external GitHub URL to internal `/leaderboard` route, keeping users on the site

## What it looks like
- Navbar now has a "Leaderboard" link that opens an in-site page
- The page displays the full OpenRA-Bench leaderboard (search, filter by agent type/opponent)
- Leaderboard data comes from the HF Space

## Note
The HF Space URL currently points to a development Space (`sy30678`). Should be updated to the upstream Space once that is deployed.

## Test plan
- [x] `/leaderboard` page renders with embedded Gradio leaderboard
- [x] Navbar link navigates to `/leaderboard` (not external)
- [ ] Verify on production build (`npm run build && npm run serve`)